### PR TITLE
XAWS-1: Adding README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# XWiki AWS
+
+Different packagings to deploy XWiki on AWS
+
+* Project Lead: [Vincent Massol](http://www.xwiki.org/xwiki/bin/view/XWiki/VincentMassol) [Sachin Chopra](https://www.xwiki.org/xwiki/bin/view/XWiki/sachin10101998)
+* Documentation & Download
+* [Issue Tracker] (https://jira.xwiki.org/projects/XAWS)
+* License: LGPL 2.1
+* Communication: [Mailing List](http://dev.xwiki.org/xwiki/bin/view/Community/MailingLists), [IRC](http://dev.xwiki.org/xwiki/bin/view/Community/IRC)
+* [Development Practices](http://dev.xwiki.org)
+* Translations: N/A
+* Sonar Dashboard: N/A


### PR DESCRIPTION
Adding Contributing guidelines, README files and other base repository setup files in Xwiki-aws repo.